### PR TITLE
Fix i3.config dmenu and qubes-i3-sensible-terminal entries

### DIFF
--- a/i3-settings-qubes/i3.config
+++ b/i3-settings-qubes/i3.config
@@ -32,17 +32,17 @@ set $right semicolon
 floating_modifier Mod1
 
 # start a terminal in the domain of the currently active window
-bindsym Mod1+d exec --no-startup-id i3-dmenu-desktop --dmenu="dmenu -nb #d2d2d2 -nf #000000 -sb #63a0ff"
+bindsym Mod1+Return exec qubes-i3-sensible-terminal
 
 # kill focused window
 bindsym Mod1+Shift+q kill
 
 # start dmenu (a program launcher)
-bindsym Mod1+d exec dmenu_run
+#bindsym Mod1+d exec dmenu_run
 # There also is the (new) i3-dmenu-desktop which only displays applications
 # shipping a .desktop file. It is a wrapper around dmenu, so you need that
 # installed.
-# bindsym Mod1+d exec --no-startup-id i3-dmenu-desktop
+bindsym Mod1+d exec --no-startup-id i3-dmenu-desktop --dmenu="dmenu -nb #d2d2d2 -nf #000000 -sb #63a0ff"
 
 # change focus
 bindsym Mod1+$left focus left

--- a/i3-settings-qubes/qubes-i3-sensible-terminal
+++ b/i3-settings-qubes/qubes-i3-sensible-terminal
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 run_terminal='
-for t in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st; do
+for t in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm gnome-terminal konsole roxterm xfce4-terminal termite lxterminal mate-terminal terminology st xterm; do
     command -v "$t" > /dev/null 2>&1 && exec "$t";
 done
 '


### PR DESCRIPTION
2 commits:

1. Make the bindsym under the comment that describes how to open a terminal actually open qubes-i3-sensible-terminal. Remove extra dmenu entry, so that the default configuration doesn't produce an error on start. This change should be modified if you don't want qubes-i3-sensible-terminal to be enabled by default.

2. Change the preferred terminals in qubes-i3-sensible-terminal to distinguish between qubes and dom0 by default.