### PR TITLE
floating tor browser

### DIFF
--- a/i3-settings-qubes/i3.config
+++ b/i3-settings-qubes/i3.config
@@ -175,6 +175,9 @@ bar {
 
 }
 
+# Avoids screen size fingerprinting
+for_window [title="Tor Browser"] floating enable
+
 # Use a screen locker
 exec --no-startup-id "xautolock -detectsleep -time 3 -locker 'i3lock -d -c 000000' -notify 30 -notifier \"notify-send -t 2000 'Locking screen in 30 seconds'\""
 


### PR DESCRIPTION
I've started using Qubes OS (4.0) not long ago, got two minor issues with i3, I thought it would be quicker to provide patches directly:
- qubes-i3status couldn't display the number of running qubes due to a change in qvm-ls format (I guess it comes with 4.0)
- Tor Browser should have a fixed size to avoid fingerprinting, thus I enabled floating for it as a default.
And now I'm looking at it, commit 9b93ad0 fixes issue #3413.
Edit: since there's another pull request fixing #3413, I've removed my commit.