### PR TITLE
Qube-colors update ORANGE basing on spec

### DIFF
--- a/0001-Show-qubes-domain-in-configurable-colored-borders.patch
+++ b/0001-Show-qubes-domain-in-configurable-colored-borders.patch
@@ -195,15 +195,15 @@ diff -ruN i3-4.16/src/config.c i3-4.16-patch/src/config.c
 +    INIT_COLOR(config.client[QUBE_RED].urgent,
 +        "#e53b27", "#f19b90", "#ce0000", "#f19b90");
 +
-+    config.client[QUBE_ORANGE].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_ORANGE].background = draw_util_hex_to_color("#a16e1b");
 +    INIT_COLOR(config.client[QUBE_ORANGE].focused,
-+        "#d05f03", "#d05f03", "#ffffff", "#daa67e");
++        "#eebb67", "#e79e27", "#000000", "#2770e7");
 +    INIT_COLOR(config.client[QUBE_ORANGE].focused_inactive,
-+        "#d05f03", "#7b3702", "#ffffff", "#daa67e");
++        "#eebb67", "#b87e1f", "#191919", "#1f59b8");
 +    INIT_COLOR(config.client[QUBE_ORANGE].unfocused,
-+        "#d05f03", "#7b3702", "#999999", "#daa67e");
++        "#eebb67", "#a16e1b", "#323232", "#1b4ea1");
 +    INIT_COLOR(config.client[QUBE_ORANGE].urgent,
-+        "#d05f03", "#daa67e", "#ce0000", "#daa67e");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
 +    config.client[QUBE_YELLOW].background = draw_util_hex_to_color("#121212");
 +    INIT_COLOR(config.client[QUBE_YELLOW].focused,


### PR DESCRIPTION
Current color theme differs with specifications. It is sufficient, but not correct.
These color codes derived from spec colors. They are the focused colors.

Colors specs.
https://www.qubes-os.org/doc/style-guide/
For details, and testing.
https://github.com/FireGrace/QubesOs_color_hexcodes_for_i3wm