### PR TITLE
Qube-colors update basing on spec

### DIFF
--- a/0001-Show-qubes-domain-in-configurable-colored-borders.patch
+++ b/0001-Show-qubes-domain-in-configurable-colored-borders.patch
@@ -175,95 +175,95 @@ diff -ruN i3-4.16/src/config.c i3-4.16-patch/src/config.c
 -    INIT_COLOR(config.client.focused_inactive, "#333333", "#5f676a", "#ffffff", "#484e50");
 -    INIT_COLOR(config.client.unfocused, "#333333", "#222222", "#888888", "#292d2e");
 -    INIT_COLOR(config.client.urgent, "#2f343a", "#900000", "#ffffff", "#900000");
-+    config.client[QUBE_DOM0].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_DOM0].background = draw_util_hex_to_color("#c4c4c4");
 +    INIT_COLOR(config.client[QUBE_DOM0].focused,
-+        "#522702", "#522702", "#ffffff", "#a6907d");
++        "#f7f7f7", "#f5f5f5", "#000000", "#0a0a0a");
 +    INIT_COLOR(config.client[QUBE_DOM0].focused_inactive,
-+        "#522702", "#361a01", "#ffffff", "#a6907d");
++        "#f7f7f7", "#dcdcdc", "#191919", "#232323");
 +    INIT_COLOR(config.client[QUBE_DOM0].unfocused,
-+        "#522702", "#361a01", "#999999", "#a6907d");
++        "#f7f7f7", "#c4c4c4", "#323232", "#3b3b3b");
 +    INIT_COLOR(config.client[QUBE_DOM0].urgent,
-+        "#666666", "#a6907d", "#ce0000", "#a6907d");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_RED].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_RED].background = draw_util_hex_to_color("#841b1b");
 +    INIT_COLOR(config.client[QUBE_RED].focused,
-+        "#e53b27", "#e53b27", "#ffffff", "#f19b90");
++        "#d06767", "#bd2727", "#ffffff", "#27bdbd");
 +    INIT_COLOR(config.client[QUBE_RED].focused_inactive,
-+        "#e53b27", "#902519", "#ffffff", "#f19b90");
++        "#d06767", "#971f1f", "#e5e5e5", "#1f9797");
 +    INIT_COLOR(config.client[QUBE_RED].unfocused,
-+        "#e53b27", "#902519", "#999999", "#f19b90");
++        "#d06767", "#841b1b", "#cccccc", "#1b8484");
 +    INIT_COLOR(config.client[QUBE_RED].urgent,
-+        "#e53b27", "#f19b90", "#ce0000", "#f19b90");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_ORANGE].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_ORANGE].background = draw_util_hex_to_color("#a16e1b");
 +    INIT_COLOR(config.client[QUBE_ORANGE].focused,
-+        "#d05f03", "#d05f03", "#ffffff", "#daa67e");
++        "#eebb67", "#e79e27", "#000000", "#2770e7");
 +    INIT_COLOR(config.client[QUBE_ORANGE].focused_inactive,
-+        "#d05f03", "#7b3702", "#ffffff", "#daa67e");
++        "#eebb67", "#b87e1f", "#191919", "#1f59b8");
 +    INIT_COLOR(config.client[QUBE_ORANGE].unfocused,
-+        "#d05f03", "#7b3702", "#999999", "#daa67e");
++        "#eebb67", "#a16e1b", "#323232", "#1b4ea1");
 +    INIT_COLOR(config.client[QUBE_ORANGE].urgent,
-+        "#d05f03", "#daa67e", "#ce0000", "#daa67e");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_YELLOW].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_YELLOW].background = draw_util_hex_to_color("#a1a023");
 +    INIT_COLOR(config.client[QUBE_YELLOW].focused,
-+        "#999b00", "#999b00", "#ffffff", "#cacb7c");
++        "#eeec6f", "#e7e532", "#000000", "#3234e7");
 +    INIT_COLOR(config.client[QUBE_YELLOW].focused_inactive,
-+        "#999b00", "#666700", "#ffffff", "#cacb7c");
++        "#eeec6f", "#b8b728", "#191919", "#2829b8");
 +    INIT_COLOR(config.client[QUBE_YELLOW].unfocused,
-+        "#999b00", "#666700", "#999999", "#cacb7c");
++        "#eeec6f", "#a1a023", "#323232", "#2324a1");
 +    INIT_COLOR(config.client[QUBE_YELLOW].urgent,
-+        "#999b00", "#cacb7c", "#ce0000", "#cacb7c");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_GREEN].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_GREEN].background = draw_util_hex_to_color("#3e972c");
 +    INIT_COLOR(config.client[QUBE_GREEN].focused,
-+        "#04af5b", "#04af5b", "#ffffff", "#7dd5aa");
++        "#8be379", "#5ad840", "#000000", "#be40d8");
 +    INIT_COLOR(config.client[QUBE_GREEN].focused_inactive,
-+        "#04af5b", "#02713b", "#ffffff", "#7dd5aa");
++        "#8be379", "#48ac33", "#191919", "#9833ac");
 +    INIT_COLOR(config.client[QUBE_GREEN].unfocused,
-+        "#04af5b", "#02713b", "#999999", "#7dd5aa");
++        "#8be379", "#3e972c", "#323232", "#852c97");
 +    INIT_COLOR(config.client[QUBE_GREEN].urgent,
-+        "#04af5b", "#7dd5aa", "#ce0000", "#7dd5aa");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_GRAY].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_GRAY].background = draw_util_hex_to_color("#636368");
 +    INIT_COLOR(config.client[QUBE_GRAY].focused,
-+        "#8c959f", "#8c959f", "#ffffff", "#c3c8cd");
++        "#afafb4", "#8e8e95", "#ffffff", "#95958e");
 +    INIT_COLOR(config.client[QUBE_GRAY].focused_inactive,
-+        "#8c959f", "#676d75", "#ffffff", "#c3c8cd");
++        "#afafb4", "#717177", "#e5e5e5", "#777771");
 +    INIT_COLOR(config.client[QUBE_GRAY].unfocused,
-+        "#8c959f", "#676d75", "#999999", "#c3c8cd");
++        "#afafb4", "#636368", "#cccccc", "#686863");
 +    INIT_COLOR(config.client[QUBE_GRAY].urgent,
-+        "#8c959f", "#c3c8cd", "#ce0000", "#c3c8cd");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_BLUE].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_BLUE].background = draw_util_hex_to_color("#275197");
 +    INIT_COLOR(config.client[QUBE_BLUE].focused,
-+        "#3384d6", "#3384d6", "#ffffff", "#95bee8");
++        "#739de3", "#3874d8", "#ffffff", "#d89c38");
 +    INIT_COLOR(config.client[QUBE_BLUE].focused_inactive,
-+        "#3384d6", "#1f5082", "#ffffff", "#95bee8");
++        "#739de3", "#2c5cac", "#e5e5e5", "#ac7c2c");
 +    INIT_COLOR(config.client[QUBE_BLUE].unfocused,
-+        "#3384d6", "#1f5082", "#999999", "#95bee8");
++        "#739de3", "#275197", "#cccccc", "#976d27");
 +    INIT_COLOR(config.client[QUBE_BLUE].urgent,
-+        "#3384d6", "#95bee8", "#ce0000", "#95bee8");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_PURPLE].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_PURPLE].background = draw_util_hex_to_color("#6f276f");
 +    INIT_COLOR(config.client[QUBE_PURPLE].focused,
-+        "#8f5cbe", "#8f5cbe", "#ffffff", "#c6abdd");
++        "#bb73bb", "#9f389f", "#ffffff", "#389f38");
 +    INIT_COLOR(config.client[QUBE_PURPLE].focused_inactive,
-+        "#8f5cbe", "#5c3e78", "#ffffff", "#c6abdd");
++        "#bb73bb", "#7f2c7f", "#e5e5e5", "#2c7f2c");
 +    INIT_COLOR(config.client[QUBE_PURPLE].unfocused,
-+        "#8f5cbe", "#5c3e78", "#999999", "#c6abdd");
++        "#bb73bb", "#6f276f", "#cccccc", "#276f27");
 +    INIT_COLOR(config.client[QUBE_PURPLE].urgent,
-+        "#8f5cbe", "#c6abdd", "#ce0000", "#c6abdd");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
 +
-+    config.client[QUBE_BLACK].background = draw_util_hex_to_color("#121212");
++    config.client[QUBE_BLACK].background = draw_util_hex_to_color("#141414");
 +    INIT_COLOR(config.client[QUBE_BLACK].focused,
-+        "#595959", "#595959", "#ffffff", "#a3a3a3");
++        "#5b5b5b", "#333333", "#ffffff", "#cccccc");
 +    INIT_COLOR(config.client[QUBE_BLACK].focused_inactive,
-+        "#595959", "#3a3a3a", "#ffffff", "#a3a3a3");
++        "#5b5b5b", "#1e1e1e", "#e5e5e5", "#e1e1e1");
 +    INIT_COLOR(config.client[QUBE_BLACK].unfocused,
-+        "#595959", "#3a3a3a", "#999999", "#a3a3a3");
++        "#5b5b5b", "#141414", "#cccccc", "#ebebeb");
 +    INIT_COLOR(config.client[QUBE_BLACK].urgent,
-+        "#595959", "#a3a3a3", "#ce0000", "#a3a3a3");
++        "#bd2727", "#e79e27", "#333333", "#27bdbd");
  
      /* border and indicator color are ignored for placeholder contents */
 -    INIT_COLOR(config.client.placeholder, "#000000", "#0c0c0c", "#ffffff", "#000000");


### PR DESCRIPTION
        Current i3 color theme differs from specifications. It is sufficient, but not correct.
        This commit contain color codes derived from spec colors. They are in focused colors.

        Colors specs.
        https://www.qubes-os.org/doc/style-guide/
        For details, and testing.
        https://github.com/FireGrace/QubesOs_color_hexcodes_for_i3wm