### PR TITLE
V4.18.2

### DIFF
--- a/i3.spec.in
+++ b/i3.spec.in
@@ -72,13 +72,15 @@ Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 %{!?rhel:Recommends:     rxvt-unicode}
 %{!?rhel:Recommends:     xorg-x11-apps}
 Requires:       xorg-x11-fonts-misc
-Recommends:     pulseaudio-utils
 # for i3-save-tree
 Requires:       perl(AnyEvent::I3) >= 0.12
 
+%if 0%{?rhel} != 7
+Recommends:     pulseaudio-utils
 Recommends:     dmenu
 Recommends:     i3status
 Recommends:     i3lock
+%endif
 
 %description
 Key features of i3 are correct implementation of XrandR, horizontal and vertical

--- a/i3.spec.in
+++ b/i3.spec.in
@@ -66,9 +66,8 @@ BuildRequires:  perl(Pod::Simple)
 BuildRequires:  xorg-x11-drv-dummy
 %endif
 
-Requires:       qubes-desktop-linux-common
-Requires:       dmenu
-Requires:       dzen2
+Requires: qubes-desktop-linux-common
+
 Requires:       perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 %{!?rhel:Recommends:     rxvt-unicode}
 %{!?rhel:Recommends:     xorg-x11-apps}


### PR DESCRIPTION
I've just found that for CentOS 7 the build was missing my repo epel-7-qubes (https://github.com/QubesOS/qubes-builder-rpm/pull/73).