### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-DIST ?= fc32
-VERSION := $(shell cat version)
-REL := $(shell cat rel)
+DIST ?= fc33
+VERSION := $(file <version)
+REL := $(file <rel)
 
 FEDORA_SOURCES := https://src.fedoraproject.org/rpms/i3/raw/f$(subst fc,,$(DIST))/f/sources
 SRC_FILE := i3-$(VERSION).tar.bz2
@@ -11,15 +11,13 @@ SRC_DIR ?= qubes-src
 DISTFILES_MIRROR ?= https://i3wm.org/downloads/
 UNTRUSTED_SUFF := .UNTRUSTED
 
-ifeq ($(FETCH_CMD),)
-$(error "You can not run this Makefile without having FETCH_CMD defined")
-endif
+fetch = $(or $(FETCH_CMD),$(error You can not run this Makefile without having FETCH_CMD defined))
 
 SHELL := /bin/bash
 
 %: %.sha512
-	@$(FETCH_CMD) $@$(UNTRUSTED_SUFF) $(DISTFILES_MIRROR)$@
-	@sha512sum --status -c <(printf "$$(cat $<)  -\n") <$@$(UNTRUSTED_SUFF) || \
+	@$(fetch) $@$(UNTRUSTED_SUFF) $(DISTFILES_MIRROR)$@
+	@sha512sum --strict --status -c <(printf "$(file <$<)  -\n") <$@$(UNTRUSTED_SUFF) || \
 			{ echo "Wrong SHA512 checksum on $@$(UNTRUSTED_SUFF)!"; exit 1; }
 	@mv $@$(UNTRUSTED_SUFF) $@
 
@@ -29,6 +27,10 @@ get-sources: $(SRC_FILE)
 .PHONY: verify-sources
 verify-sources:
 	@true
+
+.PHONY: clean-sources
+clean-sources:
+	@rm -f $(SRC_FILE)
 
 # This target is generating content locally from upstream project
 # 'sources' file. Sanitization is done but it is encouraged to perform

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ SRC_DIR ?= qubes-src
 
 DISTFILES_MIRROR ?= https://i3wm.org/downloads/
 UNTRUSTED_SUFF := .UNTRUSTED
-FETCH_CMD := wget --no-use-server-timestamps -q -O
+
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
 
 SHELL := /bin/bash
 


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.